### PR TITLE
Plugin falls back to default after installation

### DIFF
--- a/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
+++ b/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
@@ -129,7 +129,12 @@ public class LeastLoadBalancer extends LoadBalancer {
     		AbstractProject project = (AbstractProject) task;
     		@SuppressWarnings("unchecked")
     		LeastLoadDisabledProperty property = (LeastLoadDisabledProperty) project.getProperty(LeastLoadDisabledProperty.class);
-    		return property.isLeastLoadDisabled();
+            // If the job configuration hasn't been saved after installing the plugin, the property will be null. Assume
+            // that the use wants to enable functionality by default.
+            if(property != null) {
+                return property.isLeastLoadDisabled();
+            }
+            return false;
     	} else {
     		return true;
     	}


### PR DESCRIPTION
If the job configuration hasn't been saved after installing
this plugin, the property is not found and null will be returned.
So assume that the user wants to enable this plugin by default
if he/she installs it.

jenkins.log had following exceptions.

```
WARNING: Least load balancer failed will use fallback
java.lang.NullPointerException
        at org.bstick12.jenkinsci.plugins.leastload.LeastLoadBalancer.isDisabled(LeastLoadBalancer.java:132)
        at org.bstick12.jenkinsci.plugins.leastload.LeastLoadBalancer.map(LeastLoadBalancer.java:83)
        at hudson.model.LoadBalancer$2.map(LoadBalancer.java:148)
        at hudson.model.Queue.maintain(Queue.java:1041)
        at hudson.model.Queue.pop(Queue.java:868)
        at hudson.model.Executor.grabJob(Executor.java:289)
        at hudson.model.Executor.run(Executor.java:210)
```

After installing this fix, they were gone.
