### PR TITLE
A possible for JENKINS-23293

### DIFF
--- a/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
+++ b/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
@@ -177,13 +177,10 @@ public class LeastLoadBalancer extends LoadBalancer {
 			if(ec1 == ec2) {
 				return 0;
 			}
-
-			Computer com1 = ec1.computer;
-			Computer com2 = ec2.computer;
 			
-			if(isIdle(com1, ec1) && !isIdle(com2, ec2)) {
+			if(isSlaveIdle(ec1) && !isSlaveIdle(ec2)) {
 				return 1;
-			} else if (isIdle(com2, ec2) && !isIdle(com1, ec1)) {
+			} else if (isSlaveIdle(ec2) && !isSlaveIdle(ec1)) {
 				return -1;
 			} else {
 				return ec1.size() - ec2.size();
@@ -193,8 +190,8 @@ public class LeastLoadBalancer extends LoadBalancer {
 		
 		// Can't use computer.isIdle() as it can return false when assigned
 		// a multi-configuration job even though no executors are being used
-		private boolean isIdle(Computer computer, ExecutorChunk ec) {
-			return computer.countExecutors() - ec.size() == 0 ? true : false;
+		private boolean isSlaveIdle(ExecutorChunk ec) {
+			return ec.computer.countExecutors() - ec.size() == 0 ? true : false;
 		}
 		
 	}


### PR DESCRIPTION
I have tried to make a possible fix for [JENKINS-23293](https://issues.jenkins-ci.org/browse/JENKINS-23293)

When jobs launched from Multijob plugin or many sub jobs triggered at the same time by a "master" job, computer.countIdle() does not return the correct idling number of executors.

I am not sure this is the right fix, so any discussion is welcomed.
