### PR TITLE
Fixes Cast Exception

### DIFF
--- a/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
+++ b/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
@@ -126,7 +126,7 @@ public class LeastLoadBalancer extends LoadBalancer {
         SubTask subTask = task.getOwnerTask();
 
         if (subTask instanceof Job) {
-            Job job = (Job) task;
+            Job job = (Job) subTask;
             @SuppressWarnings("unchecked")
             LeastLoadDisabledProperty property = (LeastLoadDisabledProperty) job.getProperty(LeastLoadDisabledProperty.class);
             // If the job configuration hasn't been saved after installing the plugin, the property will be null. Assume


### PR DESCRIPTION
Exception:
```
WARNING: Least load balancer failed will use fallback
java.lang.ClassCastException: org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask cannot be cast to hudson.model.Job
        at org.bstick12.jenkinsci.plugins.leastload.LeastLoadBalancer.isDisabled(LeastLoadBalancer.java:129)
        at org.bstick12.jenkinsci.plugins.leastload.LeastLoadBalancer.map(LeastLoadBalancer.java:81)
        at hudson.model.LoadBalancer$2.map(LoadBalancer.java:157)
        at hudson.model.Queue.maintain(Queue.java:1610)
        at hudson.model.Queue$1.call(Queue.java:320)
        at hudson.model.Queue$1.call(Queue.java:317)
        at jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:108)
        at jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:98)
        at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:110)
        at java.lang.Thread.run(Thread.java:748)
```