### PR TITLE
Faster node label scheduling

### DIFF
--- a/docs/EXECUTOR_START_DELAY_ANALYSIS.md
+++ b/docs/EXECUTOR_START_DELAY_ANALYSIS.md
@@ -1,0 +1,85 @@
+# Why a node can take up to ~30s to take on work after Queue assigns an ExecutorChunk
+
+## Summary
+
+**Root cause:** The executor thread cannot make progress until **Queue.maintain()** releases the **Queue lock**. `maintain()` holds that lock for the **entire loop over all buildable items**. So an executor assigned in the first iteration sits blocked until every later buildable is processed and `maintain()` exits. With many buildables and costly work per item, that can reach tens of seconds.
+
+---
+
+## Flow from “assigned” to “running”
+
+1. **Queue.maintain()** runs (single thread, see `Queue.Maintainer` / `scheduleWithFixedDelay`).
+2. It takes the **Queue lock** once at the start and holds it for the whole run:
+   - `Queue.java` ~1496: `lock.lock()` at top of `maintain()`
+   - ~1710–1711: `lock.unlock()` only in the outer `finally` when `maintain()` is done.
+3. For each **BuildableItem** `p` in a **copy** of `buildables`:
+   - `getCauseOfBlockageForItem(p)`
+   - Build **candidates** from `parked` (one `JobOffer` per idle executor), with `getCauseOfBlockage(p)` per offer
+   - **MappingWorksheet** built from item + candidates + load predictors
+   - **loadBalancer.map(p.task, ws)** (e.g. leastload assigns an ExecutorChunk)
+   - **m.execute(wuc)** → `MappingWorksheet.Mapping.execute(WorkUnitContext)`:
+     - For each work chunk, `ExecutorChunk.execute(...)` calls `ExecutorSlot.set(WorkUnit)` on the chosen slot.
+   - **JobOffer.set(WorkUnit)** (~246–251):
+     - Sets `this.workUnit = p`
+     - Calls **executor.start(workUnit)**.
+   - **Executor.start(workUnit)** (~815–822):
+     - Sets `this.workUnit = task`
+     - Calls **super.start()** (i.e. **Thread.start()**), so the **Executor** thread actually starts (or was already running and is woken; see below).
+4. The **Executor** thread’s **run()** (~339+):
+   - Reads `workUnit`, then quickly enters **Queue.withLock(new Callable<>(){ ... })** (~368).
+   - **Queue.withLock** acquires the **same Queue lock** that `maintain()` is still holding.
+5. So: **maintain()** is still in the loop (processing more buildables). It **never** releases the lock between iterations. The executor thread therefore **blocks in Queue.withLock()** until **maintain()** exits and releases the lock in the outer `finally`.
+6. Only after the lock is released can the executor:
+   - Run the `Callable` (set executor on work unit, `queue.onStartExecuting`, create `Executable`, etc.)
+   - Leave `withLock`
+   - Call **workUnit.context.synchronizeStart()** (and then run the executable).
+
+So the **time from “Queue assigned an ExecutorChunk” to “node actually taking on work”** is at least: **time to finish the rest of the current maintain() run** (process all remaining buildables and exit).
+
+---
+
+## Why this can reach ~30 seconds
+
+- **One lock for the whole maintain():** The Queue lock is held for the **entire** `maintain()` pass, not per buildable. So work assigned in iteration 1 is blocked until the **last** iteration and the end of `maintain()`.
+- **Cost per buildable:** For each buildable, maintain() does:
+  - `getCauseOfBlockageForItem(p)` (and possibly `updateSnapshot()`)
+  - For each parked executor (often many on a big instance): `getCauseOfBlockage(p)` / `getNode()` / `node.canTake(item)` / `QueueTaskDispatcher.canTake(node, item)` etc.
+  - Building `MappingWorksheet` (candidates, load predictors if any)
+  - **loadBalancer.map(task, ws)** (plugin work: applicable chunks, filtering, sort, assign)
+  - After a successful map: `m.execute(wuc)`, `makePending(p)`, `updateSnapshot()`
+- With **many buildables** (e.g. tens or more) and **many executors** (e.g. 30+), each iteration can take on the order of **1–3+ seconds**. So 10–20 buildables × 1–2 s → **~10–30 seconds** of lock hold time. The first assigned executor waits for all of that.
+
+So even if leastload (or any balancer) **assigns work immediately to the right label**, the **node does not start that work** until the executor thread can take the Queue lock, which is only after **maintain()** finishes.
+
+---
+
+## Relevant code references (Jenkins core)
+
+| What | Where |
+|------|--------|
+| maintain() takes lock for full run | `Queue.java` ~1496 `lock.lock()`, ~1710–1711 `lock.unlock()` in finally |
+| Loop over buildables | `Queue.java` ~1624–1709 `for (BuildableItem p : new ArrayList<>(buildables))` |
+| Assignment: Mapping.execute → JobOffer.set → executor.start(workUnit) | `Queue.java` ~1687; `MappingWorksheet.java` ~316–321; `Queue.java` ~246–250; `Executor.java` ~815–822 |
+| Executor thread blocks on Queue lock | `Executor.java` ~368 `Queue.withLock(new Callable<>(){ ... })` |
+| Queue.withLock uses same lock | `Queue.java` ~1279–1329, 1409+ (`_withLock` → `lock.lock()`) |
+
+---
+
+## Possible mitigations (core or config)
+
+1. **Shorten maintain() duration** so the lock is held less long:
+   - Fewer buildables (e.g. limit concurrency so fewer items sit in buildables).
+   - Cheaper per-item work (e.g. cache or reduce work in `getCauseOfBlockage` / worksheet building / load balancer).
+2. **Release the lock between buildables** (structural change in core): e.g. release lock after each “assign and makePending” and re-acquire before the next buildable. That would allow executors assigned in earlier iterations to grab the lock and start while maintain() continues. This is a design/thread-safety change and needs careful review.
+3. **Reduce maintainInterval** (e.g. `-Dhudson.model.Queue.maintainInterval=2000`) does **not** by itself reduce this delay: it only makes the **next** maintain() run sooner; the delay for an **already-assigned** executor is still “time until the **current** maintain() releases the lock.”
+
+---
+
+## Note on “assigns work immediately to the proper label”
+
+The leastload plugin only decides **which** ExecutorChunk (and thus which node) gets the work. The actual handoff is:
+
+- **Queue** (inside maintain(), under the same lock): `m.execute(wuc)` → `JobOffer.set(workUnit)` → `executor.start(workUnit)`.
+- The **Executor** thread then needs the Queue lock in `run()` → `Queue.withLock(...)` and cannot get it until maintain() exits.
+
+So the “up to ~30 seconds” delay is **not** from the load balancer or from the node being slow to accept the label; it is from **Queue lock contention**: the executor thread is blocked waiting for the same lock that maintain() holds for the entire pass over all buildables.

--- a/docs/LEASTLOAD_DELAY_ANALYSIS.md
+++ b/docs/LEASTLOAD_DELAY_ANALYSIS.md
@@ -1,0 +1,111 @@
+# Why Least-Load Plugin Can Cause Long Delays (1+ Minute) or No Scheduling
+
+This document explains how the interaction between Jenkins core `Queue`/`LoadBalancer` and the **leastload-plugin** can produce long delays when selecting nodes by label, and why work sometimes is not scheduled even when executors are available.
+
+---
+
+## 1. When does scheduling actually run?
+
+### Queue maintenance is periodic and serialized
+
+- **`Queue.maintain()`** is the only place that assigns buildable items to executors. It:
+  - Builds a snapshot of *parked* (idle) executors.
+  - Iterates over **buildables** and, for each item, builds a `MappingWorksheet` from the current `candidates` and calls **`loadBalancer.map(task, ws)`**.
+  - If `map()` returns **null**, the item is left in buildables and tried again in a **later** maintenance run.
+
+- **When does `maintain()` run?**
+  - **Periodic timer**: `MaintainTask.periodic()` uses `Timer.get().scheduleWithFixedDelay(this, interval, interval, TimeUnit.MILLISECONDS)` with **`hudson.model.Queue.maintainInterval`** (default **5000 ms**).
+  - **On events**: `scheduleMaintenance()` is called when items are added/updated (e.g. `scheduleInternal`, queue updates). That only **submits** a run to the maintainer thread; it does not run immediately.
+
+- **Single-threaded maintenance**: The maintainer is an **`AtmostOneTaskExecutor`**. Only one `maintain()` runs at a time. If a run is already in progress, the next one (from the timer or from `scheduleMaintenance()`) is queued and runs **after** the current run finishes.
+
+**Implications:**
+
+- There is at least a **0–5 second** delay between “task becomes buildable” and the next time it is considered (next `maintain()`).
+- With **`scheduleWithFixedDelay`**, the next run is scheduled **after** the previous run **completes** plus the interval. So if one `maintain()` takes **60 seconds** (e.g. many items, slow `getCauseOfBlockageForItem` or label/node checks), the next run can start **~65 seconds** later. That easily produces **1+ minute** gaps between scheduling attempts.
+
+---
+
+## 2. Why does the leastload-plugin return null and defer work?
+
+The plugin’s **`LeastLoadBalancer.map()`** can return **null** in two main situations. When it returns null, the task **stays in buildables** and is only retried in the **next** `maintain()` cycle.
+
+### 2.1 Round-robin “available nodes this round” and label mismatch
+
+The plugin keeps a **persistent** set:
+
+```java
+private final Set<String> availableNodeNamesThisRound = new HashSet<>();
+```
+
+- **When it’s empty**: it **refreshes** from Jenkins (nodes that are online, accepting tasks, and have **at least one idle executor**).
+- It only **assigns** to nodes that are in `availableNodeNamesThisRound`.
+- After assigning a task to a node, it **removes** that node from the set (**`markNodesUsed(m)`**).
+- It **only refreshes again** when:
+  - the set is empty at the start of `map()`, or
+  - after filtering, **`chunksForThisRound.isEmpty()`**.
+
+So across **all** `map()` calls (all buildable items, across all `maintain()` cycles), the set is **not** reset at the start of each cycle. It only gets repopulated when empty or when no chunk is available for the current task.
+
+**Scenario that causes long delay or “no scheduling”:**
+
+- Suppose only **one node (e.g. A)** has the **label** required by the task.
+- In an earlier `map()` call (same or previous `maintain()`), the plugin assigned some work to **A** and **marked A as used**.
+- For the **next** task that also needs label A:
+  - **`useableChunks`** = chunks for node A (only A matches the label).
+  - **`chunksForThisRound`** = `filterToAvailableNodesThisRound(useableChunks)` = **empty**, because **A is no longer in `availableNodeNamesThisRound`**.
+  - Plugin then **refreshes**: `refreshAvailableNodes()` only adds nodes with **`countIdle() > 0`**. If **A’s executor was just assigned** and is busy, **A is not added**.
+  - So **`chunksForThisRound`** stays empty → **`map()` returns null** → task remains in buildables.
+
+So the task is **not** scheduled until a **future** `maintain()` run when:
+- It is considered again in the buildables order, and
+- When the plugin refreshes, node A has an idle executor again (e.g. previous work finished).
+
+With a **5 second** (or longer) interval between `maintain()` runs, this easily produces **10–60+ second** delays. If the single node with that label is often busy or the buildables order is unfavorable, the same task can be skipped for many cycles and appear as “doesn’t schedule at all” for a long time.
+
+### 2.2 assignGreedily fails
+
+Even when `chunksForThisRound` is non-empty, **`assignGreedily(m, chunksForThisRound, 0)`** can fail (e.g. constraints, capacity, or ordering). Then the plugin returns **null** and the item stays in buildables for the next cycle.
+
+---
+
+## 3. How label selection affects the worksheet
+
+- **Candidates** passed to `MappingWorksheet` are built in **`Queue.maintain()`** by filtering **parked** executors with **`JobOffer.getCauseOfBlockage(p)`**. That uses **`node.canTake(item)`**, which checks **label** (and other constraints). So the worksheet only contains executors on nodes that **can** take the task (e.g. match the assigned label).
+- **`MappingWorksheet`** then groups those offers by computer and applies load prediction; **`WorkChunk.applicableExecutorChunks()`** further filters by **`assignedLabel`** and capacity.
+
+So for a **label-restricted** task:
+
+- If only one node has that label, the worksheet has only that node’s chunks.
+- The leastload plugin’s **round-robin** logic then restricts to **“available this round”**. If that node was already marked used and hasn’t been refreshed (e.g. because it has no idle executor after the last assignment), **chunksForThisRound** is empty and **map() returns null**.
+
+So **label selection** doesn’t add delay by itself; the combination of **single-node-per-label** and **“available nodes this round”** plus **refresh only when idle** causes the plugin to frequently return null for that task until the next cycle when the node is idle again.
+
+---
+
+## 4. Summary: why delays can be “over one minute” and why work sometimes never runs
+
+| Cause | Effect |
+|-------|--------|
+| **Default `maintainInterval` = 5 s** | At least 0–5 s between scheduling attempts for a buildable item. |
+| **`scheduleWithFixedDelay` + slow `maintain()`** | If one `maintain()` run is slow (e.g. many items, slow `getCauseOfBlockageForItem`, label/node logic), the **next** run starts only after the previous one **finishes** plus the interval. One long run (e.g. 60 s) → next run ~65 s later → **1+ minute** between attempts. |
+| **Single maintainer thread** | `scheduleMaintenance()` does not run immediately; it queues behind the current `maintain()`. So “event-driven” maintenance still waits for the current run to finish. |
+| **Leastload returns null** | Task stays in buildables and is only retried in the **next** `maintain()`. So each null multiplies delay by one full cycle (5 s or more). |
+| **Round-robin + single node for label** | Node A (only one with the label) is marked “used”; refresh doesn’t add A back because it has no idle executor; **chunksForThisRound** is empty → **null** for every task that needs that label until A is idle again in a later cycle. |
+| **No refresh between cycles for “used” nodes** | `availableNodeNamesThisRound` is only cleared/refreshed when empty or when no chunk is available. So a task that needs a node that was used in a previous assignment can keep getting null until a refresh happens and that node has idle executors again. |
+
+Together, these explain:
+
+- **Long delays**: 5 s per cycle × many cycles where the plugin returns null (round-robin + label), plus possible long `maintain()` runs extending the actual period between runs.
+- **Work not scheduled despite free executors**: Executors may be on nodes that are either (a) not in `availableNodeNamesThisRound` (already used this “round”) or (b) not matching the task’s label. After refresh, nodes with no idle executors are excluded, so the only node with the right label might not reappear until it becomes idle in a later cycle—so the task can sit in buildables for a long time or appear to “never” run.
+
+---
+
+## 5. References in code
+
+- **Queue maintenance and interval**: `jenkins/core/src/main/java/hudson/model/Queue.java`
+  - `maintain()` (around 1491), `scheduleMaintenance()` (1200), `MaintainTask.periodic()` (2921–2924), `maintainInterval` default 5000L.
+- **Single-threaded maintainer**: `Queue` line 333 (`AtmostOneTaskExecutor`), `scheduleMaintenance()` → `maintainerThread.submit()`.
+- **Buildables loop and null handling**: `Queue.maintain()` around 1622–1681 (buildables loop, `loadBalancer.map()`, `continue` when `m == null`).
+- **Leastload round-robin and refresh**: `leastload-plugin/.../LeastLoadBalancer.java`
+  - `availableNodeNamesThisRound` (84–85), refresh when empty (112–114), filter (118), refresh when chunksForThisRound empty (119–123), return null (125–126, 134–137), `refreshAvailableNodes()` (184–186: `countIdle() <= 0` skips node), `markNodesUsed()` (211–218).

--- a/docs/MAPPING_WORKSHEET_PERFORMANCE.md
+++ b/docs/MAPPING_WORKSHEET_PERFORMANCE.md
@@ -1,0 +1,98 @@
+# Potential Performance Issues in hudson.model.queue.MappingWorksheet
+
+This document summarizes performance-sensitive behavior in `MappingWorksheet` and related code that can contribute to slow queue scheduling (e.g. when used with the leastload-plugin).
+
+---
+
+## 1. Constructor: load prediction block
+
+**Location:** `MappingWorksheet` constructor, lines 334–368.
+
+**What it does:** For each **Computer** (group of executor offers), when the task has `getEstimatedDuration() > 0`:
+
+- Builds a **Timeline** (a `TreeMap<Long, int[]>`).
+- For each **LoadPredictor** in `LoadPredictor.all()`, calls **`lp.predict(plan, computer, now, now + duration)`** and consumes up to **100** `FutureLoad` items.
+- For each `FutureLoad`, calls **`timeline.insert(start, end, numExecutors)`**, which does:
+  - **`splitAt(start)`** and **`splitAt(end)`** (each can add a new entry to the TreeMap).
+  - Iteration over `data.tailMap(start).headMap(end)` to update segment counts and compute peak.
+
+**Cost:**
+`O(computers × predictors × min(100, |predictions|) × (TreeMap ops + range size))`. With many agents, multiple predictors, and long estimated durations, this can be non-trivial. The worksheet is built **once per buildable item per maintenance cycle** in `Queue.maintain()`.
+
+**Mitigation:** Reduce number of LoadPredictors, or keep prediction logic light. For tasks with no estimated duration, this block is skipped.
+
+---
+
+## 2. `WorkChunk.applicableExecutorChunks()` and `ExecutorChunk.canAccept()`
+
+**Location:**
+`MappingWorksheet.WorkChunk.applicableExecutorChunks()` (228–236) calls **`canAccept(this)`** for **every** `ExecutorChunk`.
+`ExecutorChunk.canAccept(WorkChunk c)` (136–151) does:
+
+- Capacity check.
+- **Label check:** `c.assignedLabel != null && !c.assignedLabel.contains(node)`.
+- **Permission check** (unless skipped for flyweights): **`item.authenticate2()`** and **`nodeAcl.hasPermission2(..., Computer.BUILD)`**.
+
+**Label.contains(node):**
+In `Label.contains(Node node)` the implementation deliberately **does not** use the cached `getNodes()` set (to avoid staleness for label expressions). It calls **`matches(node)`**, which in turn uses **`node.getAssignedLabels()`** and evaluates the label expression (e.g. for `LabelAtom` it’s a lookup; for compound expressions it’s a small tree walk). So every `canAccept()` that has an assigned label does at least one `matches(node)` per executor.
+
+**Cost:**
+For **W** work chunks and **E** executor chunks, **applicableExecutorChunks()** is called once per work chunk and each call does **E** × `canAccept()`. So **W × E** label + permission checks per use. This is invoked:
+
+- In **LeastLoadBalancer:** inside **`getApplicableSortedByLoad(ws)`** for **every** work chunk (lines 240–241), so **W** calls to **applicableExecutorChunks()** → **W × E** `canAccept()` calls per map().
+- In **logMappingFailureDiagnostics()** again for each work chunk (diagnostics path).
+- In core **LoadBalancer.CONSISTENT_HASH:** once per work chunk (92).
+
+So **multiple W × E** invocations of **canAccept()** (and thus label + optional permission checks) per single **LoadBalancer.map()** call.
+
+**Mitigation:**
+- Cache **applicableExecutorChunks()** per work chunk if the same worksheet is queried many times (e.g. in leastload’s **getApplicableSortedByLoad** + diagnostics). Currently each call allocates a new list and recomputes all compatibility.
+- Label.matches(node) is already the intended fast path (no full getNodes() iteration); compound label expressions are still more work than a single atom.
+
+---
+
+## 3. `Mapping.isPartiallyValid()` and repeated `canAccept()`
+
+**Location:**
+`Mapping.isPartiallyValid()` (291–302) is used during greedy assignment (e.g. in **LeastLoadBalancer.assignGreedily()** and in default **LoadBalancer**). It iterates over the current mapping and for each assigned chunk calls **`ec.canAccept(works(i))`** again.
+
+**Cost:**
+During **assignGreedily**, **isPartiallyValid()** is called after every tentative assignment. So the same **canAccept()** (label + permission) logic runs again for each partial mapping state. With many work chunks and many candidate executors, the number of **canAccept()** calls can be large (order of “assignments tried” × “work chunks”).
+
+**Mitigation:**
+Compatibility between a (work chunk, executor chunk) pair does not change during one **map()** call. A cache keyed by (work index, executor index) could avoid repeated **canAccept()** inside **isPartiallyValid()** during the same **map()** run. This would require a small API or visibility change (e.g. cache in the worksheet or mapping).
+
+---
+
+## 4. Allocations and iteration in LeastLoadBalancer
+
+**Location:**
+LeastLoadBalancer **getApplicableSortedByLoad(ws)** (238–250):
+
+- For **each** work chunk it calls **ws.works(i).applicableExecutorChunks()**, which allocates a new **ArrayList** and iterates all executors.
+- It then **shuffle()**s the combined list and **sort()**s it.
+
+So for **W** work chunks we do **W** allocations and **W** full executor iterations, then one shuffle and one sort. Duplicate executor chunks can appear in the list (same chunk can be applicable to multiple work chunks), so the list can be larger than the executor set.
+
+**Cost:**
+Allocation and iteration scale with **W × (applicable executors per work)**. Together with the repeated **canAccept()** work above, this is a hot path for label-heavy workloads.
+
+---
+
+## 5. Summary table
+
+| Area | Issue | When it hurts |
+|------|--------|----------------|
+| **Constructor** | Load prediction: many computers × predictors × up to 100 FutureLoads × Timeline.insert | Tasks with estimated duration; many agents; multiple/heavy LoadPredictors |
+| **applicableExecutorChunks()** | No caching; W × E canAccept() (label + permission) per map() | Many work chunks and/or many executor chunks; called multiple times per map() |
+| **canAccept()** | Label.contains(node) → matches(node) and optional authenticate2 + hasPermission2 | Every (executor, work) compatibility check |
+| **isPartiallyValid()** | Repeats canAccept() for each assigned chunk on every tentative assignment | Deep or wide greedy search (many chunks, many candidates) |
+| **getApplicableSortedByLoad** | W separate applicableExecutorChunks() calls + shuffle + sort | Many work chunks; large executor set |
+
+---
+
+## 6. Practical impact
+
+- **Label-based scheduling:** The main hot path is **W × E** compatibility checks (label + permission) with no caching, and **isPartiallyValid()** repeating some of those checks during assignment. This can add up when there are many nodes and/or many work chunks (e.g. matrix jobs).
+- **Constructor:** Load prediction can add noticeable time when there are many computers and non-trivial **LoadPredictor** implementations, especially for tasks with a positive estimated duration.
+- Together with **Queue.maintain()** running only periodically and the leastload round-robin behavior, slow worksheet construction and repeated compatibility checks can make each **maintain()** run longer and thus amplify the delay before a buildable item gets a node.


### PR DESCRIPTION
- Logging changes
  - Add trace_id to logs entries; helps to track logs within the same map run.
  - Additional benchmark logging to know how long map run lasted.
  - Additional LoadBalancer logging.
- AI analysis performed on hudson.model.Queue, LoadBalancer, and MappingWorksheet.
  - [leastload delay analysis].
  - [MappingWorksheet analysis].
  - [Executor start delay analysis] after Queue assigns buildable.
- Executor availability is internally tracked by label so that capacity refresh can be performed per label and not as a set.
- Immediate assignment only occurs on remaining unassigned capacity; careful not to double-assign tasks to the same executor.  It favors waiting until the next maintain round.

Benchmarking I found a shared lock for the queue and that builds are blocked by the maintain method. The leastload plugin is able to finish its work in <10ms in a heavily loaded work environment.  The delays are primarily caused by how expensive the queue maintenance is.

The periodic run of Queue maintenance means it runs every 5s when it is idle. However, if Queue maintenance takes 30s, then it will complete the single threaded maintenance, wait 5s, and then rerun Queue maintenance.

In a heavily loaded Jenkins instance most of the time is spent on Queue holding its own lock giving only small 5 second gaps where executors can pick work from the queue.

[leastload delay analysis]: docs/LEASTLOAD_DELAY_ANALYSIS.md
[MappingWorksheet analysis]: docs/MAPPING_WORKSHEET_PERFORMANCE.md
[Executor start delay analysis]: docs/EXECUTOR_START_DELAY_ANALYSIS.md