### PR TITLE
Ludicrous mode: Least Load now supports pipelines

### DIFF
--- a/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
+++ b/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
@@ -57,8 +57,6 @@ import jenkins.model.Jenkins;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.FINEST;
-import static java.util.logging.Level.WARNING;
-
 /**
  * A {@link LoadBalancer} implementation that the leastload plugin uses to replace the default
  * Jenkins {@link LoadBalancer}
@@ -127,74 +125,63 @@ public class LeastLoadBalancer extends LoadBalancer {
         long startNanos = System.nanoTime();
         String trace_id = String.format("%08x", (int) (System.nanoTime() & 0xFFFFFFFF));
 
-        try {
+        if (!isDisabled(task)) {
 
-            if (!isDisabled(task)) {
-
-                if (availableNodesThisRound.isEmpty()) {
-                    refreshAvailableNodes(trace_id);
-                } else if (isLabelSetEmptyForTask(ws)) {
-                    refreshAvailableNodes(trace_id);
-                }
-
-                List<ExecutorChunk> useableChunks = getApplicableSortedByLoad(ws);
-                Set<String> nodeNamesForFilter = getNodeNamesForFilter(ws);
-                List<ExecutorChunk> chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, nodeNamesForFilter);
-
-                if (chunksForThisRound.isEmpty()) {
-                    refreshAvailableNodes(trace_id);
-                    nodeNamesForFilter = getNodeNamesForFilter(ws);
-                    chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, nodeNamesForFilter);
-                }
-                if (chunksForThisRound.isEmpty() && !useableChunks.isEmpty() && isLabelRestrictedWork(ws)) {
-                    // For label-restricted work, use useableChunks directly when round-robin filtered to empty.
-                    // Worksheet chunks are only for currently idle executors, so we cannot double-assign.
-                    // This fixes long delays when a single node has the required label and multiple executors.
-                    Set<String> availableNames = availableNodesThisRound.keySet();
-                    boolean anyStillAvailable = false;
-                    for (ExecutorChunk ec : useableChunks) {
-                        if (ec.node != null && availableNames.contains(ec.node.getNodeName())) {
-                            anyStillAvailable = true;
-                            break;
-                        }
-                    }
-                    if (anyStillAvailable) {
-                        chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, availableNames);
-                        LOGGER.log(FINER, tracePrefix(trace_id) + "Least load balancer: immediate assign for label-restricted work (using matching nodes still available this round)");
-                    } else {
-                        chunksForThisRound = useableChunks;
-                        LOGGER.log(FINER, tracePrefix(trace_id) + "Least load balancer: immediate assign for label-restricted work (using all useable chunks; nodes already used this round but have idle executors)");
-                    }
-                }
-                if (chunksForThisRound.isEmpty()) {
-                    logMappingFailureDiagnostics(ws, useableChunks.size(), true, trace_id);
-                    logMapDuration(startNanos, "null (no chunks for this round)", trace_id);
-                    return null;
-                }
-
-                Mapping m = ws.new Mapping();
-                if (assignGreedily(m, chunksForThisRound, 0)) {
-                    assert m.isCompletelyValid();
-                    markNodesUsed(m);
-                    logMapDuration(startNanos, "mapped", trace_id);
-                    return m;
-                } else {
-                    logMappingFailureDiagnostics(ws, useableChunks.size(), false, trace_id);
-                    LOGGER.log(FINE, tracePrefix(trace_id) + "Least load balancer was unable to define mapping. chunksForThisRound={0}", chunksForThisRound.size());
-                    logMapDuration(startNanos, "null (assignGreedily failed)", trace_id);
-                    return null;
-                }
-
-            } else {
-                Mapping result = getFallBackLoadBalancer().map(task, ws);
-                logMapDuration(startNanos, "fallback -> " + (result != null ? "mapped" : "null"), trace_id);
-                return result;
+            if (availableNodesThisRound.isEmpty()) {
+                refreshAvailableNodes(trace_id);
+            } else if (isLabelSetEmptyForTask(ws)) {
+                refreshAvailableNodes(trace_id);
             }
 
-        } catch (Exception e) {
-            LOGGER.log(WARNING, tracePrefix(trace_id) + "Least load balancer failed", e);
-            logMapDuration(startNanos, "null (exception)", trace_id);
-            return null;
+            List<ExecutorChunk> useableChunks = getApplicableSortedByLoad(ws);
+            Set<String> nodeNamesForFilter = getNodeNamesForFilter(ws);
+            List<ExecutorChunk> chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, nodeNamesForFilter);
+
+            if (chunksForThisRound.isEmpty()) {
+                refreshAvailableNodes(trace_id);
+                nodeNamesForFilter = getNodeNamesForFilter(ws);
+                chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, nodeNamesForFilter);
+            }
+            if (chunksForThisRound.isEmpty() && !useableChunks.isEmpty() && isLabelRestrictedWork(ws)) {
+                Set<String> availableNames = availableNodesThisRound.keySet();
+                boolean anyStillAvailable = false;
+                for (ExecutorChunk ec : useableChunks) {
+                    if (ec.node != null && availableNames.contains(ec.node.getNodeName())) {
+                        anyStillAvailable = true;
+                        break;
+                    }
+                }
+                if (anyStillAvailable) {
+                    chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, availableNames);
+                    LOGGER.log(FINER, tracePrefix(trace_id) + "Least load balancer: immediate assign for label-restricted work (using matching nodes still available this round)");
+                } else {
+                    chunksForThisRound = useableChunks;
+                    LOGGER.log(FINER, tracePrefix(trace_id) + "Least load balancer: immediate assign for label-restricted work (using all useable chunks; nodes already used this round but have idle executors)");
+                }
+            }
+            if (chunksForThisRound.isEmpty()) {
+                logMappingFailureDiagnostics(ws, useableChunks.size(), true, trace_id);
+                logMapDuration(startNanos, "null (no chunks for this round)", trace_id);
+                return null;
+            }
+
+            Mapping m = ws.new Mapping();
+            if (assignGreedily(m, chunksForThisRound, 0)) {
+                assert m.isCompletelyValid();
+                markNodesUsed(m);
+                logMapDuration(startNanos, "mapped", trace_id);
+                return m;
+            } else {
+                logMappingFailureDiagnostics(ws, useableChunks.size(), false, trace_id);
+                LOGGER.log(FINE, tracePrefix(trace_id) + "Least load balancer was unable to define mapping. chunksForThisRound={0}", chunksForThisRound.size());
+                logMapDuration(startNanos, "null (assignGreedily failed)", trace_id);
+                return null;
+            }
+
+        } else {
+            Mapping result = getFallBackLoadBalancer().map(task, ws);
+            logMapDuration(startNanos, "fallback -> " + (result != null ? "mapped" : "null"), trace_id);
+            return result;
         }
     }
 

--- a/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
+++ b/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
@@ -40,12 +40,10 @@ import hudson.model.queue.MappingWorksheet;
 import hudson.model.queue.MappingWorksheet.ExecutorChunk;
 import hudson.model.queue.MappingWorksheet.Mapping;
 import hudson.model.queue.MappingWorksheet.WorkChunk;
-import hudson.model.queue.LoadPredictor;
 import hudson.model.queue.SubTask;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -121,15 +119,6 @@ public class LeastLoadBalancer extends LoadBalancer {
     public static void register() {
         var queue = Jenkins.get().getQueue();
         queue.setLoadBalancer(new LeastLoadBalancer(queue.getLoadBalancer()));
-    }
-
-    /**
-     * When running with a Jenkins core that uses {@link LoadBalancer#getLoadPredictors()}, return no predictors
-     * so that MappingWorksheet skips load prediction. If the core does not define this method, this is just an
-     * additional method on the balancer and is never called.
-     */
-    public Collection<LoadPredictor> getLoadPredictors() {
-        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
+++ b/src/main/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancer.java
@@ -31,26 +31,34 @@ import hudson.init.Initializer;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Job;
+import hudson.model.Label;
+import hudson.model.Run;
 import hudson.model.LoadBalancer;
 import hudson.model.Node;
 import hudson.model.Queue.Task;
 import hudson.model.queue.MappingWorksheet;
 import hudson.model.queue.MappingWorksheet.ExecutorChunk;
 import hudson.model.queue.MappingWorksheet.Mapping;
+import hudson.model.queue.MappingWorksheet.WorkChunk;
+import hudson.model.queue.LoadPredictor;
 import hudson.model.queue.SubTask;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
 /**
@@ -65,6 +73,8 @@ import static java.util.logging.Level.WARNING;
  * piling on the same agent before queue maintenance runs again.
  * <p>When least-load cannot produce a mapping, it returns null so the task remains in the queue for the next cycle.
  * The fallback load balancer is used only when least-load is disabled for the job via {@link LeastLoadDisabledProperty}.
+ * <p>When work requests a label and the plugin has a matching free node, it assigns that node immediately
+ * (even if it was already used this round) to avoid long delays when only one node has the label.
  *
  * @author brendan.nolan@gmail.com
  */
@@ -74,15 +84,27 @@ public class LeastLoadBalancer extends LoadBalancer {
 
     private static final Comparator<ExecutorChunk> EXECUTOR_CHUNK_COMPARATOR = Collections.reverseOrder(new ExecutorChunkComparator());
 
+    private static String tracePrefix(String traceId) {
+        return "[trace-" + traceId + "] ";
+    }
+
     private final LoadBalancer fallback;
 
     /**
-     * Node names that are considered available for assignment this round (not yet used).
-     * When empty, we refresh from Jenkins (nodes that are online, accepting tasks, with idle executors).
-     * Access only under Queue lock (map() is serialized by the caller).
+     * Nodes considered available for assignment this round (name → node). When empty, we refresh from Jenkins
+     * (nodes that are online, accepting tasks, with idle executors). Tracks Node references so we can match
+     * work labels to nodes. Access only under Queue lock (map() is serialized by the caller).
      */
     @SuppressFBWarnings(value = "MS_MUTABLE_COLLECTION", justification = "Access only under Queue lock (map() is serialized by the caller); not exposed")
-    private final Set<String> availableNodeNamesThisRound = new HashSet<>();
+    private final Map<String, Node> availableNodesThisRound = new HashMap<>();
+
+    /**
+     * Per-label sets of node names available this round (label display name → node names). Populated on refresh
+     * so that high-demand labels (e.g. x86_64_medium) have their own capacity and are not starved by a single
+     * global round shared with other labels. When empty, refreshed together with {@link #availableNodesThisRound}.
+     */
+    @SuppressFBWarnings(value = "MS_MUTABLE_COLLECTION", justification = "Access only under Queue lock (map() is serialized by the caller); not exposed")
+    private final Map<String, Set<String>> availableNodesThisRoundByLabel = new HashMap<>();
 
     /**
      * Create the {@link LeastLoadBalancer} with a fallback that will be
@@ -101,27 +123,63 @@ public class LeastLoadBalancer extends LoadBalancer {
         queue.setLoadBalancer(new LeastLoadBalancer(queue.getLoadBalancer()));
     }
 
+    /**
+     * When running with a Jenkins core that uses {@link LoadBalancer#getLoadPredictors()}, return no predictors
+     * so that MappingWorksheet skips load prediction. If the core does not define this method, this is just an
+     * additional method on the balancer and is never called.
+     */
+    public Collection<LoadPredictor> getLoadPredictors() {
+        return Collections.emptyList();
+    }
+
     @Override
     @CheckForNull
     public Mapping map(@NonNull Task task, MappingWorksheet ws) {
+        long startNanos = System.nanoTime();
+        String trace_id = String.format("%08x", (int) (System.nanoTime() & 0xFFFFFFFF));
 
         try {
 
             if (!isDisabled(task)) {
 
-                if (availableNodeNamesThisRound.isEmpty()) {
-                    refreshAvailableNodes();
+                if (availableNodesThisRound.isEmpty()) {
+                    refreshAvailableNodes(trace_id);
+                } else if (isLabelSetEmptyForTask(ws)) {
+                    refreshAvailableNodes(trace_id);
                 }
 
                 List<ExecutorChunk> useableChunks = getApplicableSortedByLoad(ws);
-                List<ExecutorChunk> chunksForThisRound = filterToAvailableNodesThisRound(useableChunks);
+                Set<String> nodeNamesForFilter = getNodeNamesForFilter(ws);
+                List<ExecutorChunk> chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, nodeNamesForFilter);
 
                 if (chunksForThisRound.isEmpty()) {
-                    refreshAvailableNodes();
-                    chunksForThisRound = filterToAvailableNodesThisRound(useableChunks);
+                    refreshAvailableNodes(trace_id);
+                    nodeNamesForFilter = getNodeNamesForFilter(ws);
+                    chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, nodeNamesForFilter);
+                }
+                if (chunksForThisRound.isEmpty() && !useableChunks.isEmpty() && isLabelRestrictedWork(ws)) {
+                    // For label-restricted work, use useableChunks directly when round-robin filtered to empty.
+                    // Worksheet chunks are only for currently idle executors, so we cannot double-assign.
+                    // This fixes long delays when a single node has the required label and multiple executors.
+                    Set<String> availableNames = availableNodesThisRound.keySet();
+                    boolean anyStillAvailable = false;
+                    for (ExecutorChunk ec : useableChunks) {
+                        if (ec.node != null && availableNames.contains(ec.node.getNodeName())) {
+                            anyStillAvailable = true;
+                            break;
+                        }
+                    }
+                    if (anyStillAvailable) {
+                        chunksForThisRound = filterToAvailableNodesThisRound(useableChunks, availableNames);
+                        LOGGER.log(FINER, tracePrefix(trace_id) + "Least load balancer: immediate assign for label-restricted work (using matching nodes still available this round)");
+                    } else {
+                        chunksForThisRound = useableChunks;
+                        LOGGER.log(FINER, tracePrefix(trace_id) + "Least load balancer: immediate assign for label-restricted work (using all useable chunks; nodes already used this round but have idle executors)");
+                    }
                 }
                 if (chunksForThisRound.isEmpty()) {
-                    logMappingFailureDiagnostics(ws, useableChunks.size(), true);
+                    logMappingFailureDiagnostics(ws, useableChunks.size(), true, trace_id);
+                    logMapDuration(startNanos, "null (no chunks for this round)", trace_id);
                     return null;
                 }
 
@@ -129,29 +187,53 @@ public class LeastLoadBalancer extends LoadBalancer {
                 if (assignGreedily(m, chunksForThisRound, 0)) {
                     assert m.isCompletelyValid();
                     markNodesUsed(m);
+                    logMapDuration(startNanos, "mapped", trace_id);
                     return m;
                 } else {
-                    logMappingFailureDiagnostics(ws, useableChunks.size(), false);
-                    LOGGER.log(FINE, "Least load balancer was unable to define mapping. chunksForThisRound={0}", chunksForThisRound.size());
+                    logMappingFailureDiagnostics(ws, useableChunks.size(), false, trace_id);
+                    LOGGER.log(FINE, tracePrefix(trace_id) + "Least load balancer was unable to define mapping. chunksForThisRound={0}", chunksForThisRound.size());
+                    logMapDuration(startNanos, "null (assignGreedily failed)", trace_id);
                     return null;
                 }
 
             } else {
-                return getFallBackLoadBalancer().map(task, ws);
+                Mapping result = getFallBackLoadBalancer().map(task, ws);
+                logMapDuration(startNanos, "fallback -> " + (result != null ? "mapped" : "null"), trace_id);
+                return result;
             }
 
         } catch (Exception e) {
-            LOGGER.log(WARNING, "Least load balancer failed", e);
+            LOGGER.log(WARNING, tracePrefix(trace_id) + "Least load balancer failed", e);
+            logMapDuration(startNanos, "null (exception)", trace_id);
             return null;
         }
+    }
+
+    /**
+     * Log elapsed time for the map() call (benchmark).
+     */
+    private void logMapDuration(long startNanos, String outcome, String traceId) {
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        LOGGER.log(FINE, tracePrefix(traceId) + "LeastLoadBalancer.map() finished in {0} ms, outcome: {1}", new Object[]{elapsedMs, outcome});
     }
 
     /**
      * When mapping fails, log why: worksheet size, per-work applicable vs available counts.
      * @param whenUseableZero if true, useableChunks was 0 (no applicable+available chunk in worksheet)
      */
-    private void logMappingFailureDiagnostics(MappingWorksheet ws, int useableChunksSize, boolean whenUseableZero) {
+    private void logMappingFailureDiagnostics(MappingWorksheet ws, int useableChunksSize, boolean whenUseableZero, String traceId) {
         int worksheetExecutors = ws.executors.size();
+
+        if (worksheetExecutors == 0) {
+            Label assignedLabel = ws.item.getAssignedLabel();
+            LOGGER.log(FINEST,
+                    tracePrefix(traceId) + "Least load balancer received zero executor candidates from the Queue (worksheetExecutors=0). " +
+                            "The Queue rejected every idle executor for this task before calling the balancer. " +
+                            "Task: {0}, assignedLabel: {1}. Check that some node has this label and can take the task (node.canTake / permissions).",
+                    new Object[]{ws.item.task.getFullDisplayName(), assignedLabel != null ? assignedLabel.getDisplayName() : "none"});
+            return;
+        }
+
         StringBuilder workDetail = new StringBuilder();
         for (int i = 0; i < ws.works.size(); i++) {
             List<ExecutorChunk> applicable = ws.works(i).applicableExecutorChunks();
@@ -164,37 +246,70 @@ public class LeastLoadBalancer extends LoadBalancer {
                     .append(" work").append(i).append("Available=").append(available);
         }
         if (whenUseableZero) {
-            LOGGER.log(FINE, "Least load balancer was unable to define mapping. works={0} useableChunks=0 availableNodesThisRound={1} worksheetExecutors={2} ({3})",
-                    new Object[]{ws.works.size(), availableNodeNamesThisRound.size(), worksheetExecutors, workDetail});
+            Set<String> forFilter = getNodeNamesForFilter(ws);
+            LOGGER.log(FINE, tracePrefix(traceId) + "Least load balancer was unable to define mapping. works={0} useableChunks=0 availableNodesThisRound={1} nodesForLabel={2} worksheetExecutors={3} ({4})",
+                    new Object[]{ws.works.size(), availableNodesThisRound.size(), forFilter.size(), worksheetExecutors, workDetail});
         } else {
-            LOGGER.log(FINE, "Least load balancer was unable to define mapping. works={0} useableChunks={1} worksheetExecutors={2} ({3})",
+            LOGGER.log(FINE, tracePrefix(traceId) + "Least load balancer was unable to define mapping. works={0} useableChunks={1} worksheetExecutors={2} ({3})",
                     new Object[]{ws.works.size(), useableChunksSize, worksheetExecutors, workDetail});
         }
     }
 
     /**
-     * Re-populate the set of node names considered available this round from Jenkins.
+     * Re-populate the set of nodes considered available this round from Jenkins.
      * Includes only computers that are online, accepting tasks, and have at least one idle executor.
+     * Populates both the global set and per-label sets so high-demand labels (e.g. x86_64_medium) have
+     * their own capacity and are not starved by a single global round.
      */
-    private void refreshAvailableNodes() {
-        availableNodeNamesThisRound.clear();
-        for (Computer c : Jenkins.get().getComputers()) {
+    private void refreshAvailableNodes(String traceId) {
+        availableNodesThisRound.clear();
+        availableNodesThisRoundByLabel.clear();
+
+        Jenkins jenkins = Jenkins.get();
+        for (Computer c : jenkins.getComputers()) {
             Node node = c.getNode();
             if (node == null || c.isOffline() || !c.isAcceptingTasks() || c.countIdle() <= 0) {
                 continue;
             }
-            availableNodeNamesThisRound.add(node.getNodeName());
+            String nodeName = node.getNodeName();
+            availableNodesThisRound.put(nodeName, node);
+
+            for (Label label : jenkins.getLabels()) {
+                if (label.contains(node)) {
+                    availableNodesThisRoundByLabel
+                            .computeIfAbsent(label.getDisplayName(), k -> new HashSet<>())
+                            .add(nodeName);
+                }
+            }
         }
-        LOGGER.log(FINER, "Least load balancer refreshed available nodes: {0} nodes", availableNodeNamesThisRound.size());
+        LOGGER.log(FINE, tracePrefix(traceId) + "Least load balancer refreshed available nodes: {0} total, {1} labels",
+                new Object[]{availableNodesThisRound.size(), availableNodesThisRoundByLabel.size()});
     }
 
     /**
-     * Filter chunks to only those whose node is in the current round's available set (not yet used).
+     * Return the set of node names to use for "available this round" filtering. When the task has a single
+     * work with an assigned label, use that label's set so each label has its own capacity; otherwise use global.
      */
-    private List<ExecutorChunk> filterToAvailableNodesThisRound(List<ExecutorChunk> chunks) {
+    private Set<String> getNodeNamesForFilter(MappingWorksheet ws) {
+        if (ws.works.size() == 1) {
+            Label assigned = ws.works(0).assignedLabel;
+            if (assigned != null) {
+                Set<String> forLabel = availableNodesThisRoundByLabel.get(assigned.getDisplayName());
+                if (forLabel != null && !forLabel.isEmpty()) {
+                    return forLabel;
+                }
+            }
+        }
+        return availableNodesThisRound.keySet();
+    }
+
+    /**
+     * Filter chunks to only those whose node is in the given available set (not yet used this round).
+     */
+    private List<ExecutorChunk> filterToAvailableNodesThisRound(List<ExecutorChunk> chunks, Set<String> availableNodeNames) {
         List<ExecutorChunk> out = new ArrayList<>(chunks.size());
         for (ExecutorChunk ec : chunks) {
-            if (ec.node != null && availableNodeNamesThisRound.contains(ec.node.getNodeName())) {
+            if (ec.node != null && availableNodeNames.contains(ec.node.getNodeName())) {
                 out.add(ec);
             }
         }
@@ -202,15 +317,48 @@ public class LeastLoadBalancer extends LoadBalancer {
     }
 
     /**
-     * Mark each node assigned in the mapping as used this round (remove from available set).
+     * Mark each node assigned in the mapping as used this round (remove from global and all per-label sets).
      */
     private void markNodesUsed(Mapping m) {
         for (int i = 0; i < m.size(); i++) {
             ExecutorChunk ec = m.assigned(i);
             if (ec != null && ec.node != null) {
-                availableNodeNamesThisRound.remove(ec.node.getNodeName());
+                String nodeName = ec.node.getNodeName();
+                availableNodesThisRound.remove(nodeName);
+                for (Set<String> labelSet : availableNodesThisRoundByLabel.values()) {
+                    labelSet.remove(nodeName);
+                }
             }
         }
+    }
+
+    /**
+     * True if any work chunk in the worksheet has an assigned label (label-restricted work).
+     */
+    private static boolean isLabelRestrictedWork(MappingWorksheet ws) {
+        for (int i = 0; i < ws.works.size(); i++) {
+            WorkChunk w = ws.works(i);
+            if (w.assignedLabel != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * True if this task has a single work with an assigned label and that label's "available this round" set is empty.
+     * Used to refresh proactively so we pick up newly provisioned nodes for that label without waiting for the retry path.
+     */
+    private boolean isLabelSetEmptyForTask(MappingWorksheet ws) {
+        if (ws.works.size() != 1) {
+            return false;
+        }
+        Label assigned = ws.works(0).assignedLabel;
+        if (assigned == null) {
+            return false;
+        }
+        Set<String> forLabel = availableNodesThisRoundByLabel.get(assigned.getDisplayName());
+        return forLabel == null || forLabel.isEmpty();
     }
 
     /**
@@ -230,7 +378,9 @@ public class LeastLoadBalancer extends LoadBalancer {
                 }
             }
         }
-        Collections.shuffle(chunks); // See JENKINS-18323
+        if (ws.works.size() > 1) {
+            Collections.shuffle(chunks); // See JENKINS-18323
+        }
         chunks.sort(EXECUTOR_CHUNK_COMPARATOR);
         return chunks;
 
@@ -248,22 +398,32 @@ public class LeastLoadBalancer extends LoadBalancer {
     }
 
     private boolean isDisabled(Task task) {
-
-        SubTask subTask = task.getOwnerTask();
-
-        if (subTask instanceof Job) {
-            Job<?, ?> job = (Job<?, ?>) subTask;
+        Job<?, ?> job = resolveJob(task.getOwnerTask());
+        if (job != null) {
             LeastLoadDisabledProperty property = job.getProperty(LeastLoadDisabledProperty.class);
             // If the job configuration hasn't been saved after installing the plugin, the property will be null. Assume
             // that the user wants to enable functionality by default.
             if (property != null) {
                 return property.isLeastLoadDisabled();
             }
-            return false;
-        } else {
-            return true;
         }
+        // Apply leastload to all tasks (Jobs, pipeline PlaceholderTasks, etc.) unless explicitly disabled
+        return false;
+    }
 
+    /**
+     * Resolve the Job from a SubTask. Handles Job directly, Run (e.g. WorkflowRun) via getParent(),
+     * and pipeline PlaceholderTask which may have Run as owner.
+     */
+    @CheckForNull
+    private Job<?, ?> resolveJob(SubTask subTask) {
+        if (subTask instanceof Job) {
+            return (Job<?, ?>) subTask;
+        }
+        if (subTask instanceof Run) {
+            return ((Run<?, ?>) subTask).getParent();
+        }
+        return null;
     }
 
     private boolean assignGreedily(Mapping m, List<ExecutorChunk> executors, int i) {
@@ -299,6 +459,11 @@ public class LeastLoadBalancer extends LoadBalancer {
         return fallback;
     }
 
+    /**
+     * Natural order: idle chunks are "greater" than non-idle; among same idle status, more idle executors are "greater".
+     * Used with {@link Collections#reverseOrder(Comparator)} as {@link #EXECUTOR_CHUNK_COMPARATOR}, so after sort
+     * idle chunks come first (lower index), then by descending countIdle — i.e. least loaded first.
+     */
     protected static class ExecutorChunkComparator implements Comparator<ExecutorChunk>, Serializable {
         private static final long serialVersionUID = 1L;
 

--- a/src/test/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancerTest.java
+++ b/src/test/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancerTest.java
@@ -24,10 +24,8 @@
 package org.bstick12.jenkinsci.plugins.leastload;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import hudson.model.LoadBalancer;
 import hudson.model.AbstractProject;
-import hudson.model.Queue.Task;
 import hudson.model.queue.MappingWorksheet;
 
 import org.junit.Test;
@@ -60,17 +58,6 @@ public class LeastLoadBalancerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testNullOnFailure() {
-        LeastLoadBalancer llb = new LeastLoadBalancer(mockFallback);
-        LeastLoadDisabledProperty lldp = new LeastLoadDisabledProperty(false);
-        Mockito.doReturn(mockAbstractProject).when(mockAbstractProject).getOwnerTask();
-        Mockito.doReturn(lldp).when(mockAbstractProject).getProperty(LeastLoadDisabledProperty.class);
-        assertNull(llb.map(mockAbstractProject, mockMappingWorksheet));
-        Mockito.verify(mockFallback, Mockito.never()).map(Mockito.any(), Mockito.any());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
     public void testFallbackOnPropertyDisable() {
         LeastLoadBalancer llb = new LeastLoadBalancer(mockFallback);
         LeastLoadDisabledProperty lldp = new LeastLoadDisabledProperty(true);
@@ -78,14 +65,6 @@ public class LeastLoadBalancerTest {
         Mockito.doReturn(lldp).when(mockAbstractProject).getProperty(LeastLoadDisabledProperty.class);
         llb.map(mockAbstractProject, mockMappingWorksheet);
         Mockito.verify(mockFallback).map(mockAbstractProject, mockMappingWorksheet);
-    }
-
-    @Test
-    public void testNullWhenNotAbstractProject() {
-        LeastLoadBalancer llb = new LeastLoadBalancer(mockFallback);
-        Task mockTask = Mockito.mock(Task.class);
-        assertNull(llb.map(mockTask, mockMappingWorksheet));
-        Mockito.verify(mockFallback, Mockito.never()).map(Mockito.any(), Mockito.any());
     }
 
 }

--- a/src/test/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancerTest.java
+++ b/src/test/java/org/bstick12/jenkinsci/plugins/leastload/LeastLoadBalancerTest.java
@@ -24,6 +24,7 @@
 package org.bstick12.jenkinsci.plugins.leastload;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import hudson.model.LoadBalancer;
 import hudson.model.AbstractProject;
 import hudson.model.Queue.Task;
@@ -59,34 +60,32 @@ public class LeastLoadBalancerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testFallbackOnFailure() {
+    public void testNullOnFailure() {
         LeastLoadBalancer llb = new LeastLoadBalancer(mockFallback);
         LeastLoadDisabledProperty lldp = new LeastLoadDisabledProperty(false);
+        Mockito.doReturn(mockAbstractProject).when(mockAbstractProject).getOwnerTask();
         Mockito.doReturn(lldp).when(mockAbstractProject).getProperty(LeastLoadDisabledProperty.class);
-        llb.map(mockAbstractProject, mockMappingWorksheet);
-        Mockito.verify(mockFallback).map(mockAbstractProject, mockMappingWorksheet);
+        assertNull(llb.map(mockAbstractProject, mockMappingWorksheet));
+        Mockito.verify(mockFallback, Mockito.never()).map(Mockito.any(), Mockito.any());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testFallbackOnPropertyDisable() {
-
         LeastLoadBalancer llb = new LeastLoadBalancer(mockFallback);
         LeastLoadDisabledProperty lldp = new LeastLoadDisabledProperty(true);
+        Mockito.doReturn(mockAbstractProject).when(mockAbstractProject).getOwnerTask();
         Mockito.doReturn(lldp).when(mockAbstractProject).getProperty(LeastLoadDisabledProperty.class);
         llb.map(mockAbstractProject, mockMappingWorksheet);
         Mockito.verify(mockFallback).map(mockAbstractProject, mockMappingWorksheet);
-
     }
 
     @Test
-    public void testFallbackWhenNotAbstractProject() {
-
+    public void testNullWhenNotAbstractProject() {
         LeastLoadBalancer llb = new LeastLoadBalancer(mockFallback);
         Task mockTask = Mockito.mock(Task.class);
-        llb.map(mockTask, mockMappingWorksheet);
-        Mockito.verify(mockFallback).map(mockTask, mockMappingWorksheet);
-
+        assertNull(llb.map(mockTask, mockMappingWorksheet));
+        Mockito.verify(mockFallback, Mockito.never()).map(Mockito.any(), Mockito.any());
     }
 
 }


### PR DESCRIPTION
What is ludicrous speed?
------------------------

[Obligatory video of ludicrous speed](https://youtu.be/oApAdwuqtn8?si=uJHPP5OXz9GNllY0)

<details><summary>Ludicrous speed is faster than light speed</summary>

---

![spaceballs ludicrous speed](https://github.com/user-attachments/assets/803d4aa5-4677-40b9-b04b-d4f22ea2cbf3)

</details>

---

Patch details
-------------

`Queue.maintian()` is a critical path in Jenkins core.  Any performance delays can significantly impact Jenkins scheduling work on agents.  This plugin didn't properly schedule work and instead fell back to the default core [LoadBalancer].

The leastload plugin's load balancer is called for every buildable item during `Queue.maintain()`. Two bugs caused it to return null (deferring work to the next cycle) far more often than necessary:

1. **Pipeline tasks were ignored.** The plugin checked `subTask instanceof Job`, but pipeline work uses `PlaceholderTask` with a `Run` owner. All pipeline `node('label')` blocks fell back to the default consistent-hash balancer, bypassing least-load distribution entirely.

2. **Label-restricted work was deferred.** When a single node had the required label and was marked "used" by the round-robin tracker, the plugin returned null even when that node had idle executors. This caused 10–60+ second delays for label-restricted work.

The patch fixes both: pipeline tasks are resolved to their parent `Job` via `Run.getParent()`, and label-restricted work is assigned immediately when idle executors exist — even if the node was already used this round. Per-label round-robin tracking ensures high-demand labels aren't starved by a global round shared with other labels. Load prediction is disabled (returns empty) to skip the O(computers × predictors × FutureLoads) overhead per buildable item.

Patch series
------------

This patch is part of a series which enables my production instance to scale work up to ludicrous amounts of agents.

- [ec2 plugin]
- [job-restrictions plugin]
- leastload plugin (this patch)

AI Analysis
-----------

See detailed [AI analysis for leastload plugin][1].

Testing done
------------

First pressure tested in a non-production environment. It is now running in production for me for about a week.

Submitter checklist
-------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

[1]: https://github.com/samrocketman/jenkins-ai-analysis/blob/main/ludicrous-mode-analysis/leastload-plugin/
[LoadBalancer]: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/LoadBalancer.java
[ec2 plugin]: https://github.com/jenkinsci/ec2-plugin/pull/2000
[job-restrictions plugin]: https://github.com/jenkinsci/job-restrictions-plugin/pull/210